### PR TITLE
AWS　デプロイ

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+  root 'items#index'
+  resources :items, only: :index
 end


### PR DESCRIPTION
what
ローカル環境のルートの設定

why
ローカルとリモートを繋ぐため